### PR TITLE
Support for Java 9 and above

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,7 +4,7 @@ It inserts breakpoints into code, and tests all execution combinations for possi
 It is well explained in this talk: https://vimeo.com/105758363 and slides: http://www.slideshare.net/RafaelWinterhalter/unit-testing-concurrent-code
 
 Weaver is originally developed by Google Developers here: https://github.com/google/thread-weaver
-This forks updates libraries for Java 8 compatibility and adds mavenization needed for MapDB project.
+This forks updates libraries for Java 11 compatibility and adds mavenization needed for MapDB project.
 
 Examples are here:
 https://github.com/jankotek/thread-weaver/tree/master/src/test/java/examples

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.20.0-GA</version>
+            <version>3.23.1-GA</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/google/testing/instrumentation/InstrumentedClassLoader.java
+++ b/src/main/java/com/google/testing/instrumentation/InstrumentedClassLoader.java
@@ -44,7 +44,8 @@ public final class InstrumentedClassLoader extends ClassLoader {
   /* Note - we run into various obscure errors with on-the-fly classes if we try
    * to load sun packages, so delegate these to the parent class loader. Also
    * delegate java and javax packages, on the assumption that we don't want to
-   * instrument these.
+   * instrument these. After JDK9 we also need to delegate jdk.internal.reflect
+   * to the parent class loader.
    *
    * We also exclude classes from the JUnit and EasyMock test frameworks, from
    * Objenesis, and from org.w3c.dom, on the grounds that we are not likely to
@@ -55,7 +56,7 @@ public final class InstrumentedClassLoader extends ClassLoader {
    * callers specify this.
    */
   private static final List<String> excludedClassPrefixes =
-      Arrays.asList("java.", "javax.", "sun.", "net.sf.cglib", "junit.",
+      Arrays.asList("java.", "javax.", "sun.", "jdk.internal.reflect", "net.sf.cglib", "junit.",
           "org.junit.", "org.objenesis.", "org.easymock.", "org.w3c.dom", "org.jdom");
 
   /**


### PR DESCRIPTION
 - Default class loader loads "jdk.internal.reflect" packages
 - Upgrade "javassist" to 3.23.1-GA